### PR TITLE
German 84-key layout (gr and gr2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ resdep = mKEYBA.obj mkeybrc.obj mkeybr.obj mkeybrf.obj \
 keydefs = \
 	keydefdk.obj \
 	keydefGR.obj \
+	keystdGR.obj \
 	keydefG2.obj \
+	keystdG2.obj \
 	keydefIT.obj \
 	keystdIT.obj \
 	keydefLA.obj \
@@ -69,11 +71,23 @@ keydefgr.obj:  keydefgr.h  mkeyb.h
 	$(TCCCOMP) keydefgr.h
 	$(TLIB) keydef.lib -+ keydefgr.obj
 
+# GERMAN+STANDARD
+
+keystdgr.obj:  keydefgr.h  mkeyb.h
+	$(TCCCOMP) -okeystdgr -DSTANDARD keydefgr.h
+	$(TLIB) keydef.lib -+ keystdgr.obj
+
 # GERMAN+COMBI ( '`^ + AEIOU )
 
 keydefg2.obj: keydefgr.h  mkeyb.h
 	$(TCCCOMP) -okeydefg2 -DCOMBI keydefgr.h
 	$(TLIB) keydef.lib -+ keydefg2.obj
+
+# GERMAN+COMBI+STANDARD
+
+keystdg2.obj: keydefgr.h  mkeyb.h
+	$(TCCCOMP) -okeystdg2 -DSTANDARD -DCOMBI keydefgr.h
+	$(TLIB) keydef.lib -+ keystdg2.obj
 
 keydefsp.obj: keydefsp.h  mkeyb.h
 	$(TCCCOMP) keydefsp.h
@@ -274,3 +288,4 @@ clean:
 	del /eq mkeybrsc.asm
 
 # ############## end generic ##########################
+

--- a/keydefgr.h
+++ b/keydefgr.h
@@ -5,14 +5,25 @@
 /*
  * history
  * 20 apr 02: tom ehlert - creation
+ * 22 aug 21: pierre beck - 83/84 keyboard
  */
 
 
 #ifdef COMBI
+#ifdef STANDARD
+	#define NAME(x) x##_GR2std
+#else
 	#define NAME(x) x##_GR2
+#endif
 #else	
+#ifdef STANDARD
+	#define NAME(x) x##_GRstd
+#else
 	#define NAME(x) x##_GR
+#endif
 #endif	
+
+
 
 
 #include <dos.h>
@@ -33,9 +44,17 @@ uchar NAME(scancodetable)[] = {
  /* Y */ PUNCT_ALTGR	(0x15, 'z', 'Z', 0x1A		)
 
  /* 1 */ PUNCT		(0x02, '1', '!'		)
- /* 2 */ PUNCT		(0x03, '2', '"'		)
- /* 3 */ PUNCT		(0x04, '3',0x15		)
-//* 4 */ PUNCT		(0x05, '4', '$',0xFF	)
+#ifdef STANDARD
+ /* 2 */ PUNCT_ALTGR    (0x03, '2', '"', '@'	)
+#else
+ /* 2 */ PUNCT_ALTGR	(0x03, '2', '"', 0xFD	) /* superscript 2 */
+#endif
+#ifdef STANDARD
+ /* 3 */ PUNCT		(0x04, '3', 0xF5	) /* section sign - moved from 0x15 (control char!) to 0xF5 in cp850, users of cp437 can press ctrl-u or ctrl-alt-4 */
+#else
+ /* 3 */ PUNCT_ALTGR	(0x04, '3', 0xF5, 0xFC	) /* section sign, superscript 3 */
+#endif
+ /* 4 */ PUNCT_ALTGR	(0x05, '4', '$', 0x15	) /* bonus key: section sign for cp437 users */
  /* 5 */ ALTGR		(0x06,EURO		)
  /* 6 */ PUNCT		(0x07, '6', '&'		)
  /* 7 */ PUNCT_ALTGR	(0x08, '7', '/', '{'	)
@@ -50,20 +69,41 @@ uchar NAME(scancodetable)[] = {
  /* = */ PUNCT		(0x0D,'\'', '`'		) /* PUNCT_CTRL '+` */
 #endif
  /* Q */ ALTGR		(0x10, '@'		)
+#ifdef STANDARD
+ /* [ */ ALPHA_ALTGR    (0x1A,0x81,0x9a, '['	) /* ue */
+ /* ] */ PUNCT_ALTGR	(0x1B, '+', '*', ']'	)
+#else
  /* [ */ ALPHA		(0x1A,0x81,0x9a		) /* ue */
  /* ] */ PUNCT_ALTGR	(0x1B, '+', '*', '~'	)
+#endif
  /* ; */ ALPHA		(0x27,0x94,0x99		) /* german umlauts oe */
  /* ' */ ALPHA		(0x28,0x84,0x8E		) /* ae */
+#ifdef STANDARD
+#ifdef COMBI
+ /* ` */ PUNCT		(0x29, '#', COMBI3	) /* COMBI ^ + aeiou */
+#else
+ /* ` */ PUNCT		(0x29, '#', '^'		) /* ^ */
+#endif
+#else
 #ifdef COMBI
  /* ` */ PUNCT		(0x29,COMBI3,0xF8	) /* COMBI ^ + aeiou */
 #else
  /* ` */ PUNCT		(0x29, '^',0xF8		) /* ^ */
 #endif
+#endif
+#ifdef STANDARD
+ /* \ */ PUNCT_ALTGR    (0x2B, '<', '>', '\\'	)
+#else
  /* \ */ PUNCT		(0x2B, '#','\''		)
+#endif
  /* M */ ALTGR		(0x32,0xE6		) /* greek mue */
  /* , */ PUNCT		(0x33, ',', ';'		)
  /* . */ PUNCT		(0x34, '.', ':'		)
+#ifdef STANDARD
+ /* / */ PUNCT_ALTGR	(0x35, '-', '_', '|'	) /* bonus key: pipe on ctrl-alt - */
+#else
  /* / */ PUNCT		(0x35, '-', '_'		)
+#endif
  /*   */ PUNCT_ALTGR	(0x56, '<', '>', '|'	)       
  
  /* E */ ALTGR           (0x12, EURO)          // Added by Snoopy81
@@ -82,7 +122,7 @@ uchar NAME(scancodetable)[] = {
 
 #ifdef COMBI
 
-uchar NAME(combi1table)[] = {		/* ' a† eÇ i° o¢ u£ Eê #32' */
+uchar NAME(combi1table)[] = {		/* ' aÔøΩ eÔøΩ iÔøΩ oÔøΩ uÔøΩ EÔøΩ #32' */
 	/*scancode lower upper*/
  /* A */ 0x1E, 0xA0, 0xB5,
  /* E */ 0x12, 0x82, 0x90,
@@ -93,7 +133,7 @@ uchar NAME(combi1table)[] = {		/* ' a† eÇ i° o¢ u£ Eê #32' */
 	 0
 };
 
-uchar NAME(combi2table)[] = {		/* ` aÖ eä iç oï uó #32` */
+uchar NAME(combi2table)[] = {		/* ` aÔøΩ eÔøΩ iÔøΩ oÔøΩ uÔøΩ #32` */
 	/*scancode lower upper*/
  /* A */ 0x1E, 0x85, 0xB7,
  /* E */ 0x12, 0x8A, 0xD4,
@@ -104,7 +144,7 @@ uchar NAME(combi2table)[] = {		/* ` aÖ eä iç oï uó #32` */
 	 0
 };
 
-uchar NAME(combi3table)[] = {		/* ^ aÉ eà iå oì uñ #32^ */
+uchar NAME(combi3table)[] = {		/* ^ aÔøΩ eÔøΩ iÔøΩ oÔøΩ uÔøΩ #32^ */
 	/*scancode lower upper*/
  /* A */ 0x1E, 0x83, 0xB6,
  /* E */ 0x12, 0x88, 0xD2,
@@ -135,32 +175,33 @@ uchar NAME(combi6table)[] = {		/* something missing yet ?? */
 #ifndef COMBI
 struct KeyboardDefinition NAME(Keyboard) = {
 	"GR",                                          //char LanguageShort[4];			// "GR",                    
-	"GERMAN - deutsche Tastatur (by tom)",  //char *Description;				// created by, "with combis"
-	DRIVER_FUNCTION_NORMAL,                        //char DriverFunctionRequired;                                  
-	NAME(scancodetable),                           //char *ScancodeTable;                                          
-#ifdef COMBI
-	{	NAME(combi1table),NAME(combi2table),NAME(combi3table),
-		NAME(combi4table),NAME(combi5table),NAME(combi6table) },
+#ifdef STANDARD
+	"GERMAN - 83/84 Tasten (by tom & Pierre)",  //char *Description;
+	DRIVER_FUNCTION_STANDARD,                      //char DriverFunctionRequired;
 #else
+	"GERMAN - deutsche Tastatur (by tom)",  //char *Description;				// created by, "with combis"
+	DRIVER_FUNCTION_NORMAL,                        //char DriverFunctionRequired;
+#endif
+	NAME(scancodetable),                           //char *ScancodeTable;                                          
 	{ 0 },
-#endif			
 	',',                                           //char DezimalDingsbums;                                        
 	0,                                             //char DefaultLayoutUS;			// TRUE for russian             
-	} ;
+};
 #else
-	struct KeyboardDefinition NAME(Keyboard) = {
-		"GR2",                                      //char LanguageShort[4];			// "GR",                    
-		"GERMAN2 - deutsche Tastatur mit internatinalen Umlauten (by tom)", //char *Description;				// created by, "with combis"
-		DRIVER_FUNCTION_FULL,                       //char DriverFunctionRequired;                                  
-		NAME(scancodetable),                        //char *ScancodeTable;                                          
-#ifdef COMBI
+struct KeyboardDefinition NAME(Keyboard) = {
+	"GR2",                                      //char LanguageShort[4];			// "GR",
+#ifdef STANDARD
+	"GERMAN2 - 83/84 Tasten mit internationalen Umlauten (by tom & Pierre)", //char *Description; // created by, "with combis"
+	DRIVER_FUNCTION_STD_FULL,                       //char DriverFunctionRequired;                                  
+#else
+	"GERMAN2 - deutsche Tastatur mit internationalen Umlauten (by tom)", //char *Description; // created by, "with combis"
+	DRIVER_FUNCTION_FULL,                       //char DriverFunctionRequired;                                  
+#endif
+	NAME(scancodetable),                        //char *ScancodeTable;                                          
 	{	NAME(combi1table),NAME(combi2table),NAME(combi3table),
 		NAME(combi4table),NAME(combi5table),NAME(combi6table) },
-#else
-	{ 0 },
-#endif			
-		',',                                        //char DezimalDingsbums;                                        
-		0,                                          //char DefaultLayoutUS;			// TRUE for russian             
-		};
+	',',                                        //char DezimalDingsbums;                                        
+	0,                                          //char DefaultLayoutUS;			// TRUE for russian             
+};
 #endif
 

--- a/mkeyb.c
+++ b/mkeyb.c
@@ -622,7 +622,9 @@ extern struct KeyboardDefinition
 	,Keyboard_BGP
 	,Keyboard_DK
 	,Keyboard_GR
+	,Keyboard_GRstd
 	,Keyboard_GR2
+	,Keyboard_GR2std
 	,Keyboard_IT
 	,Keyboard_ITstd
 	,Keyboard_LA
@@ -689,8 +691,8 @@ struct KeyboardDefinition *StdKeyDefTab[] =
 	,&Keyboard_BX
 	,&Keyboard_DK
 	,&Keyboard_FR
-	,&Keyboard_GR
-	,&Keyboard_GR2
+	,&Keyboard_GRstd
+	,&Keyboard_GR2std
 	,&Keyboard_HE
 	,&Keyboard_ITstd
 	,&Keyboard_LA


### PR DESCRIPTION
Hi,

first of all, a big THANK YOU for this project. I was losing hope I could ever run MS DOS 6.22 on my XT clone because the included keyboard driver unfortunately crashes the machine. After testing several alternatives, this patched mkeyb worked perfectly.

I took the liberty of adding my 84-key variant to the german layouts gr and gr2:

![grafik](https://user-images.githubusercontent.com/3186931/185812445-9630b4e6-60f7-4fdd-b539-496a26b4ef93.png)

Also, some minor tweaks and cleanups:

Change for standard and enhanced layout: section sign § now cp850 compliant
Bonus key: Ctrl-Alt-4: cp437 section sign (backup for affected users)

The ASCII code for section sign "§" changed between cp437 and cp850. It is either broken for cp437 users or cp850 users. Since most of the code targets cp850 anyways and the section sign is very rarely used, I feel confident changing it to 0xF5. If any user is negatively affected by this, ctrl-alt-4 will output the old character as a compromise. A more clean solution down the road would be to add a command line flag to signal which codepage is loaded and adapt accordingly.

Add for enhanced layout: superscript 2 and 3.

They're located on ctrl-alt-2 and ctrl-alt-3. The euro sign from modern keyboards is included, might include these as well.

Bonus key for standard layout: Ctrl-Alt-Dash = Pipe

The pipe character was missing on german 84-key keyboards. Badly. When DOS 2 introduced piping, the character became essential. Therefore this bonus key to make pipe accessible for standard keyboards.

Also note:

I did not clear most of the enhanced key combos for the 84-key. For example: ctrl-alt-q still produces an @, and ctrl-alt-ß still produces a backslash. I think it is user friendly to have those common combos align with modern era keyboards as long as no conflicts arise.