### PR TITLE
Allow building with GCC-ia16

### DIFF
--- a/Makefile.bcc
+++ b/Makefile.bcc
@@ -58,134 +58,134 @@ keydefs = \
 mkeyb.exe: mkeyb.obj  $(resdep) $(depends) $(keydefs)
 	$(TCCLINK) mKEYB.obj $(resdep) $(depends) keydef.lib
 
-mkeyb.obj: mkeyb.c mkeyb.h
+mkeyb.obj: mkeyb.c mkeyb.h portab.h
 	$(TCCCOMP) -DMY_INSTALL_SIGNATURE=$(INST_SIG) -DMY_VERSION_SIGNATURE=$(VERSION) -DMY_VERSION_TEXT=$(VERSION_STR) mKEYB.c
 
 # GERMAN
 
-keydefgr.obj:  keydefgr.h  mkeyb.h
+keydefgr.obj:  keydefgr.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefgr.h
 	$(TLIB) keydef.lib -+ keydefgr.obj
 
 # GERMAN+STANDARD
 
-keystdgr.obj:  keydefgr.h  mkeyb.h
+keystdgr.obj:  keydefgr.h  mkeyb.h portab.h
 	$(TCCCOMP) -okeystdgr -DSTANDARD keydefgr.h
 	$(TLIB) keydef.lib -+ keystdgr.obj
 
 # GERMAN+COMBI ( '`^ + AEIOU )
 
-keydefg2.obj: keydefgr.h  mkeyb.h
+keydefg2.obj: keydefgr.h  mkeyb.h portab.h
 	$(TCCCOMP) -okeydefg2 -DCOMBI keydefgr.h
 	$(TLIB) keydef.lib -+ keydefg2.obj
 
 # GERMAN+COMBI+STANDARD
 
-keystdg2.obj: keydefgr.h  mkeyb.h
+keystdg2.obj: keydefgr.h  mkeyb.h portab.h
 	$(TCCCOMP) -okeystdg2 -DSTANDARD -DCOMBI keydefgr.h
 	$(TLIB) keydef.lib -+ keystdg2.obj
 
-keydefsp.obj: keydefsp.h  mkeyb.h
+keydefsp.obj: keydefsp.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsp.h
 	$(TLIB) keydef.lib -+ keydefsp.obj
 
-keydefru.obj: keydefru.h  mkeyb.h
+keydefru.obj: keydefru.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefru.h
 	$(TLIB) keydef.lib -+ keydefru.obj
 
-keydefdk.obj: keydefdk.h  mkeyb.h
+keydefdk.obj: keydefdk.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefdk.h
 	$(TLIB) keydef.lib -+ keydefdk.obj
 
-keydefit.obj: keydefit.h  mkeyb.h
+keydefit.obj: keydefit.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefit.h
 	$(TLIB) keydef.lib -+ keydefit.obj
 
-keystdit.obj: keydefit.h  mkeyb.h
+keystdit.obj: keydefit.h  mkeyb.h portab.h
 	$(TCCCOMP) -okeystdit -DSTANDARD keydefit.h
 	$(TLIB) keydef.lib -+ keystdit.obj
 
-keydefla.obj: keydefla.h  mkeyb.h
+keydefla.obj: keydefla.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefla.h
 	$(TLIB) keydef.lib -+ keydefla.obj
 
-keydefnl.obj: keydefnl.h  mkeyb.h
+keydefnl.obj: keydefnl.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefnl.h
 	$(TLIB) keydef.lib -+ keydefnl.obj
 
-keydefno.obj: keydefno.h  mkeyb.h
+keydefno.obj: keydefno.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefno.h
 	$(TLIB) keydef.lib -+ keydefno.obj
 
-keydefpl.obj: keydefpl.h  mkeyb.h
+keydefpl.obj: keydefpl.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefpl.h
 	$(TLIB) keydef.lib -+ keydefpl.obj
 
-keydefpo.obj: keydefpo.h  mkeyb.h
+keydefpo.obj: keydefpo.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefpo.h
 	$(TLIB) keydef.lib -+ keydefpo.obj
 
-keydefsf.obj: keydefsf.h  mkeyb.h
+keydefsf.obj: keydefsf.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsf.h
 	$(TLIB) keydef.lib -+ keydefsf.obj
 
-keydefsg.obj: keydefsg.h  mkeyb.h
+keydefsg.obj: keydefsg.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsg.h
 	$(TLIB) keydef.lib -+ keydefsg.obj
 
-keydefsu.obj: keydefsu.h  mkeyb.h
+keydefsu.obj: keydefsu.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsu.h
 	$(TLIB) keydef.lib -+ keydefsu.obj
 
-keydefsv.obj: keydefsv.h  mkeyb.h
+keydefsv.obj: keydefsv.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsv.h
 	$(TLIB) keydef.lib -+ keydefsv.obj
 
-keydefuk.obj: keydefuk.h  mkeyb.h
+keydefuk.obj: keydefuk.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefuk.h
 	$(TLIB) keydef.lib -+ keydefuk.obj
 
-keydefbr.obj: keydefbr.h  mkeyb.h
+keydefbr.obj: keydefbr.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefbr.h
 	$(TLIB) keydef.lib -+ keydefbr.obj
 
-keydefbx.obj: keydefbx.h  mkeyb.h
+keydefbx.obj: keydefbx.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefbx.h
 	$(TLIB) keydef.lib -+ keydefbx.obj
 
-keydeffr.obj: keydeffr.h  mkeyb.h
+keydeffr.obj: keydeffr.h  mkeyb.h portab.h
 	$(TCCCOMP) keydeffr.h
 	$(TLIB) keydef.lib -+ keydeffr.obj
 
-keydefhe.obj: keydefhe.h  mkeyb.h
+keydefhe.obj: keydefhe.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefhe.h
 	$(TLIB) keydef.lib -+ keydefhe.obj
 
-keydefbe.obj: keydefbe.h  mkeyb.h
+keydefbe.obj: keydefbe.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefbe.h
 	$(TLIB) keydef.lib -+ keydefbe.obj
 
-keydefbg.obj: keydefbg.h  mkeyb.h
+keydefbg.obj: keydefbg.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefbg.h
 	$(TLIB) keydef.lib -+ keydefbg.obj
 
-keydefbp.obj: keydefbp.h  mkeyb.h
+keydefbp.obj: keydefbp.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefbp.h
 	$(TLIB) keydef.lib -+ keydefbp.obj
 
-keydefsl.obj: keydefsl.h  mkeyb.h
+keydefsl.obj: keydefsl.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefsl.h
 	$(TLIB) keydef.lib -+ keydefsl.obj
 
-keydefux.obj: keydefux.h  mkeyb.h
+keydefux.obj: keydefux.h  mkeyb.h portab.h
 	$(TCCCOMP) keydefux.h
 	$(TLIB) keydef.lib -+ keydefux.obj
 
-keydeftr.obj: keydeftr.h  mkeyb.h
+keydeftr.obj: keydeftr.h  mkeyb.h portab.h
 	$(TCCCOMP) keydeftr.h
 	$(TLIB) keydef.lib -+ keydeftr.obj
 
-keydeftf.obj: keydeftf.h  mkeyb.h
+keydeftf.obj: keydeftf.h  mkeyb.h portab.h
 	$(TCCCOMP) keydeftf.h
 	$(TLIB) keydef.lib -+ keydeftf.obj
 
@@ -208,57 +208,57 @@ mkeybA.obj: mkeybA.ASM
 # resident part
 #
 
-mkeybr.obj: mkeybr.c
+mkeybr.obj: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt    -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    mKEYBr.c
 
-mkeybr.asm: mkeybr.c
+mkeybr.asm: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt -S -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    mKEYBr.c
 
 #
 # resident part with combi
 #
-mkeybrC.obj: mkeybr.c
+mkeybrC.obj: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt    -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DCOMBI -omkeybrC mKEYBr.c
 
-mkeybrC.asm: mkeybr.c
+mkeybrC.asm: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt -S -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DCOMBI -omkeybrC mKEYBr.c
 
 #
 # FASTSWITCH resident part without ALTGREY, REPLACESCAN, DECIMALDINGSBUMS
 # The right Ctrl toggles between native QWERTY and national keyboard
 #
-mkeybrf.obj: mkeybr.c
+mkeybrf.obj: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt    -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DFASTSWITCH -omkeybrF mKEYBr.c
 
-mkeybrf.asm: mkeybr.c
+mkeybrf.asm: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt -S -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DFASTSWITCH -omkeybrF mKEYBr.c
 
 #
 # resident part for 83 keys "standard" keyboards
 #
-mkeybrS.obj: mkeybr.c
+mkeybrS.obj: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt    -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DSTANDARD -omkeybrS mKEYBr.c
 
-mkeybrS.asm: mkeybr.c
+mkeybrS.asm: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt -S -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DSTANDARD -omkeybrS mKEYBr.c
 
 #
 # resident part for 83 keys "standard" keyboards with COMBI
 #
-mkeybrSC.obj: mkeybr.c
+mkeybrSC.obj: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt    -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DSTD_FULL -omkeybrSC mKEYBr.c
 
-mkeybrSC.asm: mkeybr.c
+mkeybrSC.asm: mkeybr.c mkeyb.h portab.h
 	$(TCCCOMP) -mt -S -zAINIT -zCI_TEXT -zDIB -zRID -zTID -zPI_GR -zBIB -zGI_GR -zSI_GR    -DSTD_FULL -omkeybrSC mKEYBr.c
 
-prf.obj: prf.c
+prf.obj: prf.c portab.h
 	$(TCCCOMP) -DFORSYS prf.c
 
 sscani.obj: sscani.c
 	$(TCCCOMP) sscani.c
 
 #useful when debugging/analysing code
-mkeyb.asm: mkeyb.c mkeyb.h
+mkeyb.asm: mkeyb.c mkeyb.h portab.h
 	$(TCCCOMP) -S mKEYB.c
 
 # Pack executable and create zip file for release

--- a/Makefile.bcc
+++ b/Makefile.bcc
@@ -254,9 +254,6 @@ mkeybrSC.asm: mkeybr.c mkeyb.h portab.h
 prf.obj: prf.c portab.h
 	$(TCCCOMP) -DFORSYS prf.c
 
-sscani.obj: sscani.c
-	$(TCCCOMP) sscani.c
-
 #useful when debugging/analysing code
 mkeyb.asm: mkeyb.c mkeyb.h portab.h
 	$(TCCCOMP) -S mKEYB.c

--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -1,0 +1,238 @@
+all: mkeyb.exe
+
+INST_SIG:=19309			# mKEYB fingerprint "mK"
+VERSION:=54				# version number
+VERSION_STR:=\"0.54\"		# version number text
+
+CFLAGS:=-masm=intel -mcmodel=small -march=i8086 -Os -std=gnu89 -Wall -Wextra
+CFLAGS+=-Werror
+CFLAGS_INIT:=
+# these are important to keep symbols in expected order
+CFLAGS_KEYDEF:=-fno-toplevel-reorder -fno-zero-initialized-in-bss
+# resident part also can't assume ds == ss
+CFLAGS_RESIDENT:=-fno-toplevel-reorder -mno-callee-assume-ss-data-segment
+ASFLAGS:=-c --defsym=MY_INSTALL_SIGNATURE=$(INST_SIG) --defsym=MY_VERSION_SIGNATURE=$(VERSION)
+LDFLAGS:=-mcmodel=small
+LDLIBS:=-li86
+OBJDUMPFLAGS:=-M intel,addr16,data16 -z
+
+CC:=ia16-elf-gcc
+AS:=ia16-elf-as
+OBJDUMP:=ia16-elf-objdump
+
+.SUFFIXES:
+.PHONY: listings clean distclean
+
+depends:=prf.o
+resdep:=mkeyba1.o mkeybrc.o mkeybr.o mkeybrf.o mkeybrs.o mkeybrsc.o mkeyba2.o
+keydefs:= \
+	keydefdk.o \
+	keydefgr.o \
+	keystdgr.o \
+	keydefg2.o \
+	keystdg2.o \
+	keydefit.o \
+	keystdit.o \
+	keydefla.o \
+	keydefnl.o \
+	keydefno.o \
+	keydefpl.o \
+	keydefpo.o \
+	keydefru.o \
+	keydefsf.o \
+	keydefsg.o \
+	keydefsp.o \
+	keydefsu.o \
+	keydefsv.o \
+	keydefuk.o \
+	keydefbr.o \
+	keydefbx.o \
+	keydeffr.o \
+	keydefhe.o \
+	keydefbe.o \
+	keydefbg.o \
+	keydefbp.o \
+	keydefsl.o \
+	keydefux.o \
+	keydeftr.o \
+	keydeftf.o \
+
+listfiles = mkeyb.lst mkeybr.lst mkeybrc.lst mkeybrf.lst mkeybrs.lst mkeybrsc.lst mkeyba1.lst mkeyba2.lst
+
+#
+# MAIN EXECUTABLE
+#
+mkeyb.exe: $(resdep) mkeyb.o $(depends) $(keydefs)
+	$(CC) $(LDFLAGS) -o $@ -Wl,-Map=mkeyb.map $^ $(LDLIBS)
+
+mkeyb.o: mkeyb.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_INIT) -o $@ -c -DMY_INSTALL_SIGNATURE=$(INST_SIG) -DMY_VERSION_SIGNATURE=$(VERSION) -DMY_VERSION_TEXT=$(VERSION_STR) mkeyb.c
+
+# must specify -x c because otherwise gcc creates precompiled headers from .h
+
+# GERMAN
+
+keydefgr.o: keydefgr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefgr.h
+
+# GERMAN+STANDARD
+
+keystdgr.o: keydefgr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ -DSTANDARD keydefgr.h
+
+# GERMAN+COMBI ( '`^ + AEIOU )
+
+keydefg2.o: keydefgr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ -DCOMBI keydefgr.h
+
+# GERMAN+COMBI+STANDARD
+
+keystdg2.o: keydefgr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ -DSTANDARD -DCOMBI keydefgr.h
+
+keydefsp.o: keydefsp.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsp.h
+
+keydefru.o: keydefru.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefru.h
+
+keydefdk.o: keydefdk.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefdk.h
+
+keydefit.o: keydefit.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefit.h
+
+keystdit.o: keydefit.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ -DSTANDARD keydefit.h
+
+keydefla.o: keydefla.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefla.h
+
+keydefnl.o: keydefnl.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefnl.h
+
+keydefno.o: keydefno.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefno.h
+
+keydefpl.o: keydefpl.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefpl.h
+
+keydefpo.o: keydefpo.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefpo.h
+
+keydefsf.o: keydefsf.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsf.h
+
+keydefsg.o: keydefsg.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsg.h
+
+keydefsu.o: keydefsu.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsu.h
+
+keydefsv.o: keydefsv.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsv.h
+
+keydefuk.o: keydefuk.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefuk.h
+
+keydefbr.o: keydefbr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefbr.h
+
+keydefbx.o: keydefbx.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefbx.h
+
+keydeffr.o: keydeffr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydeffr.h
+
+keydefhe.o: keydefhe.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefhe.h
+
+keydefbe.o: keydefbe.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefbe.h
+
+keydefbg.o: keydefbg.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefbg.h
+
+keydefbp.o: keydefbp.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefbp.h
+
+keydefsl.o: keydefsl.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefsl.h
+
+keydefux.o: keydefux.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydefux.h
+
+keydeftr.o: keydeftr.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydeftr.h
+
+keydeftf.o: keydeftf.h mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_KEYDEF) -c -x c -o $@ keydeftf.h
+
+# ############## generic ##########################
+#
+# for all languages same:
+#
+
+#
+#assembly stub
+#
+mkeyba1.o: mkeyba1.S
+	$(AS) $(ASFLAGS) -o $@ $<
+mkeyba2.o: mkeyba2.S
+	$(AS) $(ASFLAGS) -o $@ $<
+
+#
+# resident part
+#
+
+mkeybr.o: mkeybr.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_RESIDENT) -c -o $@ mkeybr.c
+
+#
+# resident part with combi
+#
+mkeybrc.o: mkeybr.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_RESIDENT) -c -o $@ -DCOMBI mkeybr.c
+
+#
+# FASTSWITCH resident part without ALTGREY, REPLACESCAN, DECIMALDINGSBUMS
+# The right Ctrl toggles between native QWERTY and national keyboard
+#
+mkeybrf.o: mkeybr.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_RESIDENT) -c -o $@ -DFASTSWITCH mkeybr.c
+
+#
+# resident part for 83 keys "standard" keyboards
+#
+mkeybrs.o: mkeybr.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_RESIDENT) -c -o $@ -DSTANDARD mkeybr.c
+
+#
+# resident part for 83 keys "standard" keyboards with COMBI
+#
+mkeybrsc.o: mkeybr.c mkeyb.h portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_RESIDENT) -c -o $@ -DSTD_FULL mkeybr.c
+
+prf.o: prf.c portab.h
+	$(CC) $(CFLAGS) $(CFLAGS_INIT) -c -o $@ -DFORSYS prf.c
+
+
+# useful when debugging/analysing code
+%.lst: %.o
+	$(OBJDUMP) $(OBJDUMPFLAGS) -D $< > $@
+
+listings: $(listfiles)
+
+# cleanup
+clean:
+	rm -f *.o
+	rm -f *~
+	rm -f *.map
+	rm -f *.lst
+	rm -f *.err
+
+distclean: clean
+	rm -f *.exe
+
+# ############## end generic ##########################
+

--- a/Makefile.wcc
+++ b/Makefile.wcc
@@ -233,7 +233,7 @@ mkeybrc.lst: mkeybrc.o
 mkeybrf.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)        -DFASTSWITCH -fo=mkeybrf mkeybr.c
 
-mkeybrf.lst: mkeybrc.o
+mkeybrf.lst: mkeybrf.o
 	$(WDIS) -l mkeybrf
 
 #
@@ -242,7 +242,7 @@ mkeybrf.lst: mkeybrc.o
 mkeybrs.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)        -DSTANDARD -fo=mkeybrs mkeybr.c
 
-mkeybrs.lst: mkeybrc.o
+mkeybrs.lst: mkeybrs.o
 	$(WDIS) -l mkeybrs
 
 #

--- a/Makefile.wcc
+++ b/Makefile.wcc
@@ -61,134 +61,134 @@ mkeyb.exe: mkeyb.o  $(resdep) $(depends) $(keydefs)
 	$(WCCLINK) system dos file {mkeyb.o $(resdep) $(depends) keydef.lib} option map=mkeyb name mkeyb
 	$(PACK) mkeyb.exe
 
-mkeyb.o: mkeyb.c mkeyb.h
+mkeyb.o: mkeyb.c mkeyb.h portab.h
 	$(WCCCOMP) -DMY_INSTALL_SIGNATURE=$(INST_SIG) -DMY_VERSION_SIGNATURE=$(VERSION) -DMY_VERSION_TEXT=$(VERSION_STR) mkeyb.c
 
 # GERMAN
 
-keydefgr.o:  keydefgr.h  mkeyb.h
+keydefgr.o:  keydefgr.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefgr.h
 	$(TLIB) keydef.lib -+keydefgr.o
 
 # GERMAN+STANDARD
 
-keystdgr.o:  keydefgr.h  mkeyb.h
+keystdgr.o:  keydefgr.h  mkeyb.h portab.h
 	$(WCCCOMP) -fo=keystdgr -DSTANDARD keydefgr.h
 	$(TLIB) keydef.lib -+keystdgr.o
 
 # GERMAN+COMBI ( '`^ + AEIOU )
 
-keydefg2.o: keydefgr.h  mkeyb.h
+keydefg2.o: keydefgr.h  mkeyb.h portab.h
 	$(WCCCOMP) -fo=keydefg2 -DCOMBI keydefgr.h
 	$(TLIB) keydef.lib -+keydefg2.o
 
 # GERMAN+COMBI+STANDARD
 
-keystdg2.o: keydefgr.h  mkeyb.h
+keystdg2.o: keydefgr.h  mkeyb.h portab.h
 	$(WCCCOMP) -fo=keystdg2 -DSTANDARD -DCOMBI keydefgr.h
 	$(TLIB) keydef.lib -+keystdg2.o
 
-keydefsp.o: keydefsp.h  mkeyb.h
+keydefsp.o: keydefsp.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsp.h
 	$(TLIB) keydef.lib -+keydefsp.o
 
-keydefru.o: keydefru.h  mkeyb.h
+keydefru.o: keydefru.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefru.h
 	$(TLIB) keydef.lib -+keydefru.o
 
-keydefdk.o: keydefdk.h  mkeyb.h
+keydefdk.o: keydefdk.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefdk.h
 	$(TLIB) keydef.lib -+keydefdk.o
 
-keydefit.o: keydefit.h  mkeyb.h
+keydefit.o: keydefit.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefit.h
 	$(TLIB) keydef.lib -+keydefit.o
 
-keystdit.o: keydefit.h  mkeyb.h
+keystdit.o: keydefit.h  mkeyb.h portab.h
 	$(WCCCOMP) -fo=keystdit -DSTANDARD keydefit.h
 	$(TLIB) keydef.lib -+keystdit.o
 
-keydefla.o: keydefla.h  mkeyb.h
+keydefla.o: keydefla.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefla.h
 	$(TLIB) keydef.lib -+keydefla.o
 
-keydefnl.o: keydefnl.h  mkeyb.h
+keydefnl.o: keydefnl.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefnl.h
 	$(TLIB) keydef.lib -+keydefnl.o
 
-keydefno.o: keydefno.h  mkeyb.h
+keydefno.o: keydefno.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefno.h
 	$(TLIB) keydef.lib -+keydefno.o
 
-keydefpl.o: keydefpl.h  mkeyb.h
+keydefpl.o: keydefpl.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefpl.h
 	$(TLIB) keydef.lib -+keydefpl.o
 
-keydefpo.o: keydefpo.h  mkeyb.h
+keydefpo.o: keydefpo.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefpo.h
 	$(TLIB) keydef.lib -+keydefpo.o
 
-keydefsf.o: keydefsf.h  mkeyb.h
+keydefsf.o: keydefsf.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsf.h
 	$(TLIB) keydef.lib -+keydefsf.o
 
-keydefsg.o: keydefsg.h  mkeyb.h
+keydefsg.o: keydefsg.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsg.h
 	$(TLIB) keydef.lib -+keydefsg.o
 
-keydefsu.o: keydefsu.h  mkeyb.h
+keydefsu.o: keydefsu.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsu.h
 	$(TLIB) keydef.lib -+keydefsu.o
 
-keydefsv.o: keydefsv.h  mkeyb.h
+keydefsv.o: keydefsv.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsv.h
 	$(TLIB) keydef.lib -+keydefsv.o
 
-keydefuk.o: keydefuk.h  mkeyb.h
+keydefuk.o: keydefuk.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefuk.h
 	$(TLIB) keydef.lib -+keydefuk.o
 
-keydefbr.o: keydefbr.h  mkeyb.h
+keydefbr.o: keydefbr.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefbr.h
 	$(TLIB) keydef.lib -+keydefbr.o
 
-keydefbx.o: keydefbx.h  mkeyb.h
+keydefbx.o: keydefbx.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefbx.h
 	$(TLIB) keydef.lib -+keydefbx.o
 
-keydeffr.o: keydeffr.h  mkeyb.h
+keydeffr.o: keydeffr.h  mkeyb.h portab.h
 	$(WCCCOMP) keydeffr.h
 	$(TLIB) keydef.lib -+keydeffr.o
 
-keydefhe.o: keydefhe.h  mkeyb.h
+keydefhe.o: keydefhe.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefhe.h
 	$(TLIB) keydef.lib -+keydefhe.o
 
-keydefbe.o: keydefbe.h  mkeyb.h
+keydefbe.o: keydefbe.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefbe.h
 	$(TLIB) keydef.lib -+keydefbe.o
 
-keydefbg.o: keydefbg.h  mkeyb.h
+keydefbg.o: keydefbg.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefbg.h
 	$(TLIB) keydef.lib -+keydefbg.o
 
-keydefbp.o: keydefbp.h  mkeyb.h
+keydefbp.o: keydefbp.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefbp.h
 	$(TLIB) keydef.lib -+keydefbp.o
 
-keydefsl.o: keydefsl.h  mkeyb.h
+keydefsl.o: keydefsl.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefsl.h
 	$(TLIB) keydef.lib -+keydefsl.o
 
-keydefux.o: keydefux.h  mkeyb.h
+keydefux.o: keydefux.h  mkeyb.h portab.h
 	$(WCCCOMP) keydefux.h
 	$(TLIB) keydef.lib -+keydefux.o
 
-keydeftr.o: keydeftr.h  mkeyb.h
+keydeftr.o: keydeftr.h  mkeyb.h portab.h
 	$(WCCCOMP) keydeftr.h
 	$(TLIB) keydef.lib -+keydeftr.o
 
-keydeftf.o: keydeftf.h  mkeyb.h
+keydeftf.o: keydeftf.h  mkeyb.h portab.h
 	$(WCCCOMP) keydeftf.h
 	$(TLIB) keydef.lib -+keydeftf.o
 
@@ -211,7 +211,7 @@ mkeyba.o: mkeyba.asm
 # resident part
 #
 
-mkeybr.o: mkeybr.c
+mkeybr.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)  mkeybr.c
 
 mkeybr.lst: mkeybr.o
@@ -220,7 +220,7 @@ mkeybr.lst: mkeybr.o
 #
 # resident part with combi
 #
-mkeybrc.o: mkeybr.c
+mkeybrc.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)  -DCOMBI -fo=mkeybrc mkeybr.c
 
 mkeybrc.lst: mkeybrc.o
@@ -230,7 +230,7 @@ mkeybrc.lst: mkeybrc.o
 # FASTSWITCH resident part without ALTGREY, REPLACESCAN, DECIMALDINGSBUMS
 # The right Ctrl toggles between native QWERTY and national keyboard
 #
-mkeybrf.o: mkeybr.c
+mkeybrf.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)        -DFASTSWITCH -fo=mkeybrf mkeybr.c
 
 mkeybrf.lst: mkeybrc.o
@@ -239,7 +239,7 @@ mkeybrf.lst: mkeybrc.o
 #
 # resident part for 83 keys "standard" keyboards
 #
-mkeybrs.o: mkeybr.c
+mkeybrs.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)        -DSTANDARD -fo=mkeybrs mkeybr.c
 
 mkeybrs.lst: mkeybrc.o
@@ -248,7 +248,7 @@ mkeybrs.lst: mkeybrc.o
 #
 # resident part for 83 keys "standard" keyboards with COMBI
 #
-mkeybrsc.o: mkeybr.c
+mkeybrsc.o: mkeybr.c mkeyb.h portab.h
 	$(WCCCOMP)        -DSTD_FULL -fo=mkeybrsc mkeybr.c
 
 mkeybrsc.lst: mkeybrc.o

--- a/mkeyb.c
+++ b/mkeyb.c
@@ -552,6 +552,8 @@ int InstallKeyboard(struct KeyboardDefinition *kb,
 
 	VerifyScancodeTableForCorrectness(kb,0);
 
+	memset(&r, 0, sizeof(r));
+
 	/*
 	 * Do this before copying.
 	 * Save only the handlers that will be installed.

--- a/mkeyb.c
+++ b/mkeyb.c
@@ -167,7 +167,12 @@ void VerifyScancodeTableForCorrectness(	struct KeyboardDefinition *kb,int print)
 		lasttbl = tbl;
 	}
 
-	if (tbl + 1 != scancode_end)
+	if (tbl + 1 != scancode_end
+#ifdef __GNUC__
+		/* GCC-ia16 aligns symbols to 2 bytes which sometimes adds an extra byte */
+		&& tbl + 2 != scancode_end
+#endif  /* __GNUC__ */
+	   )
 	{
 		printf("scancode table error: early zero found at offset 0x%2x last scan 0x%02x\n",
 				tbl-kb->ScancodeTable, lasttbl[0]);

--- a/mkeyb.h
+++ b/mkeyb.h
@@ -9,6 +9,9 @@
 #if __WATCOMC__
     #define getvect _dos_getvect
     #define setvect _dos_setvect
+#elif defined(__GNUC__)
+    #define getvect _dos_getvect
+    #define setvect _dos_setvect
 #endif
 
 typedef unsigned long   ulong;

--- a/mkeyba1.S
+++ b/mkeyba1.S
@@ -1,0 +1,113 @@
+.intel_syntax noprefix
+.code16
+
+.section .fartext._0
+
+.globl int2f_handler,OldInt2F
+.globl int15_handler,OldInt15
+
+# SEGMENT_START:
+
+int2f_handler:
+	cmp ax, 0x0ad80
+	jne int2f_82
+	mov ax, MY_INSTALL_SIGNATURE	# Report mKEYB installed
+	mov bx, MY_VERSION_SIGNATURE	# BH is major BL is minor version
+	mov di, cs
+	mov es, di
+	mov di, offset OldInt9			# ES:DI points to data block
+	iret
+
+int2f_82:
+	cmp ax, 0x0ad82
+	jne int2f_83
+	mov [cs:usebiosonly_flag],bl
+	iret
+
+int2f_83:
+	cmp ax, 0x0ad83
+	jne chain_int2f
+	mov bl,[cs:usebiosonly_flag]
+	iret
+
+chain_int2f:
+	.byte 0xea		# Jump Far
+OldInt2F:  	.word 0, 0
+
+
+.globl  cint15_handler_full
+
+int15_handler:
+	jnc chain_int15_non_carry
+
+	cmp ah, 0x04f
+	jne chain_int15
+
+	push bx
+	push cx
+	push dx
+	push ds
+	push es
+
+	push cs
+	pop  ds
+	push ax                     # push argument to stack
+	call cint15_handler_full
+	pop cx						# pop argument from stack
+
+	pop es
+	pop ds
+	pop dx
+	pop cx
+	pop bx
+
+						# scancode if pass down key to BIOS
+						# 0  if scancode was handled
+	mov ah, 0x04f
+	cmp al,0
+	jne chain_int15
+
+#	clc       					# no good idea, as the win2K
+#	sti							# DOS box behaves erratically
+#	ret2
+
+	push bp
+	mov  bp,sp
+	and  byte ptr [bp+6], 0x0fe		# clear carry
+	pop bp
+	iret
+
+chain_int15:
+	stc
+chain_int15_non_carry:
+	.byte 0xea		# Jump Far
+OldInt15:  	.word 0,0
+
+#extern uchar usebiosonly_flag#
+#extern uchar debug_scancode#
+#extern uint  RESIDENT currentCombi             #
+#extern uchar RESIDENT currentCombiScancode     #
+#extern uint  RESIDENT ResidentCombiTables[5]   #
+#extern uchar RESIDENT DecimalDingsBums         #    /* grey , or . */
+#extern char  *ResidentScancodetable#
+
+.globl OldInt9
+.globl OldInt16
+
+.globl usebiosonly_flag
+.globl Flags
+
+.globl debug_scancode, currentCombi
+.globl ResidentCombiTables, DecimalDingsBums
+.globl pResidentScancodetable
+#extrn ResidentScancodetable
+
+OldInt9:                .word 0,0
+OldInt16:               .word 0,0
+usebiosonly_flag:       .byte 0x0ff
+Flags: 			.byte 0
+debug_scancode:         .byte 0
+currentCombi:           .word 0
+DecimalDingsBums:       .byte 0
+ResidentCombiTables:    .word 0,0,0,0,0,0
+pResidentScancodetable: .word 0

--- a/mkeyba2.S
+++ b/mkeyba2.S
@@ -1,0 +1,79 @@
+.intel_syntax noprefix
+.code16
+
+.section .fartext._2
+
+
+.globl int9_handler
+.globl int16_handler, END_int16_handler
+
+    #  ? ASSUME CS:I_GROUP
+
+# Optional handlers for INT9 and INT16
+int9_handler:
+	jmp int9_start			# Workaround for APL software
+int9_isActiveF: .word 1    		# Modified by APL software
+int9_start:
+	# save the registers
+	push ax        		# scancode
+	# compute if we should handle the extended
+	mov al, byte ptr [cs:int9_isActiveF]
+	or al, al
+	jz chain_int9
+	# read and authenticate scancode
+	in al, 0x60		# get the scancode in AL
+	mov ah, 0x4f		# authenticate scancode
+	stc
+
+	int 0x15			# return: CF clear if no further processing
+	jc chain_int9
+	# clear keyboard buffer
+	in al, 0x61		# read status register
+	or al, 0x80		# set bit 7
+	out 0x61, al
+	and al, 0x7f		# clear bit 7
+	out 0x61, al
+	# report end of interrupt to interrupt controller
+	mov al, 0x20
+	out 0x20, al
+	jmp leave_int9
+chain_int9:
+	pushf
+	call dword ptr [cs:OldInt9]
+	# leave interrupt routine
+leave_int9:
+	pop ax
+	iret
+
+int16_handler:
+	cmp ah, 05 		# check INT 16 function number
+	jne chain_int16		# call old handler if != 05
+	# save registers
+	push di
+	push ds
+	mov di, 0x040
+	mov ds, di
+	mov di, [ds:0x001C]
+	mov [di], cx
+	add di, 2
+	cmp di, [ds:0x0082]
+	jne int16_1
+	mov di,[ds:0x0080]
+int16_1:
+	cmp di,[ds:0x001]
+	je int16_2
+	mov [ds:0x001C], di
+	xor al, al
+	jmp int16_3
+int16_2:
+	mov al,01
+int16_3:
+	pop ds
+	pop di
+	iret
+
+chain_int16:
+	jmp dword ptr [cs:OldInt16]
+
+END_int16_handler:
+	nop

--- a/mkeybr.c
+++ b/mkeybr.c
@@ -91,6 +91,21 @@ extern uchar *pResidentScancodetable;
 				 "int 0x16"              \
 				 __parm   [ch] [cl]      \
 				 __modify [ax];
+#elif defined(__GNUC__)
+	// must be inlined or computer will crash
+	static inline void GENERATE_KEYSTROKE(uchar scancode, uchar keycode) __attribute__((always_inline));
+	static inline void GENERATE_KEYSTROKE(uchar scancode, uchar keycode) {
+		register uchar cl asm ("cl") = keycode;
+		register uchar ch asm ("ch") = scancode;
+		__asm__ volatile (                          \
+				 "mov ah, 5\n"                      \
+				 "int 0x16\n"                       \
+				 : /* output */                     \
+				 : /* input */ "cl" (cl), "ch" (ch) \
+				 : /* clobber */ "a"                \
+
+		);
+	}
 #else
 	#define GENERATE_KEYSTROKE(scancode,keycode)        \
 		_CL = keycode,                                  \
@@ -108,8 +123,14 @@ extern uchar *pResidentScancodetable;
 */
 
 
+#ifdef __GNUC__
+#define SECTION_ATTR __attribute__((section(".fartext._1")))
+#else  /* __GNUC__ */
+#define SECTION_ATTR
+#endif  /* __GNUC__ */
 
-int cdecl NAME(cint15_handler)(uchar scancode)
+
+SECTION_ATTR int cdecl NAME(cint15_handler)(uchar scancode)
 {
 	uchar  RESIDENT *tbl;
 	ushort BIOSstate;
@@ -379,6 +400,6 @@ simulateKeyPress:
 	}
 	#pragma aux NAME(END_cint15_handler) "_*"
 #else
-	void NAME(END_cint15_handler)(void){};
+	SECTION_ATTR void NAME(END_cint15_handler)(void){};
 #endif
 

--- a/portab.h
+++ b/portab.h
@@ -87,6 +87,20 @@ void __int__(int);
 #define I386
 #endif
 
+#elif defined(__GNUC__)
+
+#include <dos.h>
+
+#define CDECL
+#define cdecl
+#define CONST const
+#define far __far
+#define FAR __far
+#define interrupt
+#define near
+#define REG
+#define VOID void
+
 #elif defined (_MYMC68K_COMILER_)
 
 #define MC68K
@@ -212,7 +226,11 @@ typedef signed long LONG;
 #define FP_OFF(fp)             (fp)
 #endif
 
+#ifdef __GNUC__
+typedef __libi86_isr_t intvec;
+#else
 typedef void (interrupt far *intvec)();
+#endif
 
 /*
 	this suppresses the warning

--- a/prf.c
+++ b/prf.c
@@ -113,7 +113,17 @@ VOID put_console(COUNT c)
   if (c == '\n')
     put_console('\r');
 
-#ifdef FORSYS
+#ifdef __GNUC__
+  register char ah asm ("ah") = 0x02;
+  register char dl asm ("dl") = c;
+  __asm__ volatile (                          \
+           "int 0x21\n"                       \
+           : /* output */                     \
+           : /* input */ "ah" (ah), "dl" (dl) \
+           : /* clobber */                    \
+
+  );
+#elif defined(FORSYS)
   /* write(1, &c, 1); */       /* write character to stdout */
   asm{
     mov ah, 0x02


### PR DESCRIPTION
This allows building with GCC-ia16. It compiles but does not work. The installation seems to work but then crashes immediately with invalid opcode fault. There's something wrong with the memory copying, possibly things are still in wrong order in the executable.

Building with Borland C 3.1 is broken and the fix is not trivial. This probably breaks it more.

Open Watcom version still works after all my changes so this should be entirely safe.

I didn't find a clean way to build the assembly part from single source so it's now essentially duplicated for both compilers.

The first 13 commits are general cleanups which I found during porting. Would you like them as a separate PR?
